### PR TITLE
Brittasegling 2018 update

### DIFF
--- a/data.py
+++ b/data.py
@@ -203,7 +203,7 @@ dishes = NameDict([
                 Ingredient(name=u"Salt",           quantity=None),
                 Ingredient(name=u"Peppar, svart",  quantity=None)
                 ], variants={
-                "veg": [
+                "vegetarian": [
                     Ingredient(name=u"Quornfiléer", quantity=1*units.count)
                     ]
                 }),
@@ -221,7 +221,7 @@ dishes = NameDict([
                 Ingredient(name=u"Salt",                 quantity=None),
                 Ingredient(name=u"Pasta, Penne",         quantity=5 * units.kilogram),
                 ], variants={
-                u"veg": [
+                u"vegetarian": [
                     Ingredient(name=u"Quornfiléer", quantity=2*units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count)
                     ],
@@ -249,7 +249,7 @@ dishes = NameDict([
                 "glutenfri": [
                     Ingredient(name=u"Pasta, glutenfri, portioner", quantity=1*units.count)
                     ],
-                "veg": [
+                "vegetarian": [
                     Ingredient(name=u"Quornburgare", quantity=1*units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count)
                     ],
@@ -277,7 +277,7 @@ dishes = NameDict([
                     Ingredient(name=u"Mjölk, laktosfri", quantity=1 * units.deciliters),
                     Ingredient(name=u"Creme Fraiche, laktosfri", quantity=.5 * units.deciliters),
                     ],
-                "veg": [
+                "vegetarian": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count)
                     ],
                 u"mjölkfri": [
@@ -300,13 +300,13 @@ dishes = NameDict([
                 Ingredient(name=u"Peppar, svart",        quantity=None),
                 Ingredient(name=u"Creme Fraiche",  quantity=2 * units.liters),
                  ], variants={                
-                u"helveg": [
+                u"vegan": [
                     Ingredient(name=u"Vegetarisk ärtsoppa burk", quantity=1 * units.count)
                 ],
                 u"laktosfri": [
                     Ingredient(name=u"Gräddfil, laktosfri", quantity=1 * units.deciliters)
                     ],
-                u"veg": [],
+                u"vegetarian": [],
                 }),
         Dish(name=u"Lax", ingredients=[
                 Ingredient(name=u"Salt, grov",           quantity=None),
@@ -319,7 +319,7 @@ dishes = NameDict([
                 Ingredient(name=u"Gräddfil",             quantity=3 * units.liters),                
                 Ingredient(name=u"Lax",                  quantity= 150 * 1.10 * 36 * units.gram),                
                 ], variants={
-                u"helveg": [
+                u"vegan": [
                     Ingredient(name=u"Vegetarisk ärtsoppa burk", quantity=1 * units.count)
                 ],
                 u"laktosfri": [
@@ -346,7 +346,7 @@ dishes = NameDict([
                 Ingredient(name=u"Citroner",             quantity=3 * units.count),
                 Ingredient(name=u"Ris, basmati",         quantity=6 * units.liters),
                 ], variants={
-                u"veg": [],
+                u"vegetarian": [],
                 u"laktosfri": [],
                 }),
     Dish(name=u"Porterstek", ingredients=[
@@ -373,7 +373,7 @@ dishes = NameDict([
                 u"mjölkfri": [
                     Ingredient(name=u"Grädde, mjölkfri", quantity=1 * units.deciliters)
                     ],
-                "veg": [
+                "vegetarian": [
                     Ingredient(name=u"Quornfiléer", quantity=2*units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count),
                     ],
@@ -392,7 +392,7 @@ dishes = NameDict([
                 Ingredient(name=u"Fransk senap",         quantity=7 * units.tablespoons),
                 Ingredient(name=u"Peppar, svart",        quantity=None),
                 ], variants={
-                u"veg": [
+                u"vegetarian": [
                     Ingredient(name=u"Quornburgare", quantity=2 * units.count)
                     ],
                 u"laktosfri": [],
@@ -407,10 +407,10 @@ dishes = NameDict([
                 "laktosfri": [
                     Ingredient(name=u"Gräddfil, laktosfri", quantity=.5 * units.deciliters)
                     ],
-                u"helveg": [
+                u"vegan": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
                 ],
-                u"veg": [],
+                u"vegetarian": [],
                 }),
     Dish(name=u"Brunch", ingredients=[
                 Ingredient(name=u"Bacon",                quantity=12*125 * units.grams),                
@@ -425,10 +425,10 @@ dishes = NameDict([
                 u"laktosfri": [
                     Ingredient(name=u"Grädde, laktosfri", quantity=0.2 * units.deciliters)
                     ],
-                u"helveg": [
+                u"vegan": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
                 ],
-                u"veg": [
+                u"vegetarian": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),                
                 ],
                 }),                
@@ -446,7 +446,7 @@ dishes = NameDict([
                 Ingredient(name=u"Olja, raps",           quantity=1.6 * units.deciliters),
                 Ingredient(name=u"Bröd, ljust, skivor",  quantity=40 * units.count),                
                 ], variants={
-                "veg": [
+                "vegetarian": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count),
                     ],
@@ -456,10 +456,10 @@ dishes = NameDict([
                 Ingredient(name=u"Rödbetor till pytt-i-panna, portioner", quantity=40 * units.count),
                 Ingredient(name=u"Pytt i panna, portioner", quantity=40 * units.count),
                 ], variants={
-                "veg": [
+                "vegetarian": [
                     Ingredient(name=u"Pytt i panna, vegetarisk, portioner", quantity=1 * units.count),
                     ],
-                "helveg": [
+                "vegan": [
                     Ingredient(name=u"Pytt i panna, vegetarisk, portioner", quantity=1 * units.count),
                     ],
                 "laktosfri" : []
@@ -470,9 +470,9 @@ dishes = NameDict([
                 "hannah": [ 
                     Ingredient(name=u"Färdigrätt, åt Hannah H E", quantity=1 * units.count) 
                     ],
-                u"veg" : [], # blandar inte i kött i en andel
-                u"helveg" : [], # blandar inte i kött i en andel
-                u"laktosfri" : [] # blandar inte i kött i en andel
+                u"vegetarian" : [], # blandar inte i kött i en andel
+                u"vegan" : [],      # blandar inte i kött i en andel
+                u"laktosfri" : []   
                 }),
     Dish(name=u"Extras", ingredients=[
                 Ingredient(name=u"Ketchup", quantity=2 * units.count),
@@ -541,25 +541,25 @@ dishes = NameDict([
 # mjölkfri
 # glutenfri
 # veg
-# helveg
+# vegan
 
 menu = [
     MenuItem(dish=dishes[u"Fänkål och kycklingsallad"], day=u"måndag"),
     MenuItem(dish=dishes[u"Pasta & köttfärssås"],       day=u"måndag"),
     MenuItem(dish=dishes[u"Korv stroganoff"],           day=u"tisdag"),
 #    MenuItem(dish=dishes[u"Lax"], day=u"tisdag"),
-    MenuItem(dish=dishes[u"Fisksoppa"],                 day=u"tisdag",  variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"2 x Indisk curry"],          day=u"onsdag",  variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Porterstek"],                day=u"onsdag",  variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Kassler med potatissallad"], day=u"torsdag", variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Kycklinggryta med fetaost"], day=u"torsdag", variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Sill och potatis"],          day=u"fredag",  variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Brunch"],                    day=u"lördag",  variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Gulasch"],                   day=u"lördag",  variants={"laktosfri": 1, "veg": 3}),
-    MenuItem(dish=dishes[u"Pytt-i-panna"],              day=u"söndag",  variants={"laktosfri": 1, "veg": 3}),    
+    MenuItem(dish=dishes[u"Fisksoppa"],                 day=u"tisdag",  variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"2 x Indisk curry"],          day=u"onsdag",  variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Porterstek"],                day=u"onsdag",  variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Kassler med potatissallad"], day=u"torsdag", variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Kycklinggryta med fetaost"], day=u"torsdag", variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Sill och potatis"],          day=u"fredag",  variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Brunch"],                    day=u"lördag",  variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Gulasch"],                   day=u"lördag",  variants={"laktosfri": 1, "vegetarian": 3}),
+    MenuItem(dish=dishes[u"Pytt-i-panna"],              day=u"söndag",  variants={"laktosfri": 1, "vegetarian": 3}),    
     MenuItem(dish=dishes[u"Frukost/fika"],              day=None,       variants={"laktosfri": 1, u"mjölkfri": 0, "glutenfri": 1}),
     MenuItem(dish=dishes[u"Extras"],                    day=None),
-    MenuItem(dish=dishes[u"Chili"],                     day=None,       variants={"laktosfri": 1, "veg": 3 }),
+    MenuItem(dish=dishes[u"Chili"],                     day=None,       variants={"laktosfri": 1, "vegetarian": 3 }),
     ]
 
 translations = [

--- a/data.py
+++ b/data.py
@@ -143,7 +143,7 @@ ingredient_types = NameDict([
     Ingredient(name=u'Kakmix, chokladkaka',purchase_unit=units.count, category=u"torr"),
     Ingredient(name=u'Marmelad',purchase_unit=units.kilogram, category=u"burk"),
     Ingredient(name=u'Russin',purchase_unit=units.kilogram, category=u"torr"),
-    Ingredient(name=u'Ljust bröd, skivor',purchase_unit=units.count, category=u"torr"),
+    Ingredient(name=u'Ljust bröd (typ polar), skivor',purchase_unit=units.count, category=u"torr"),
     Ingredient(name=u'Äppelmos',purchase_unit=units.kilogram, category=u"burk"),
     Ingredient(name=u'Mörkt bröd, skivor',purchase_unit=units.count, category=u"torr"),
     Ingredient(name=u'Frukt, blandad prisvärd',purchase_unit=units.kilogram, category=u"grönt"),
@@ -171,8 +171,12 @@ ingredient_types = NameDict([
     Ingredient(name=u"Hollandaise, mjölkfri", purchase_unit=units.grams, category=u"kyl",),
     Ingredient(name=u"Mjölkfri Creme Fraiche", purchase_unit=units.milliliters, category=u"mejeri"),
     Ingredient(name=u"Riktigt jävla smör", purchase_unit=units.grams, category=u"mejeri"),
-    Ingredient(name=u"Soyamjölk", purchase_unit=units.liters, category=u"mejeri"),
+    Ingredient(name=u"Sojamjölk", purchase_unit=units.liters, category=u"mejeri"),
     Ingredient(name=u"Maizena, ej ljus/mörk", purchase_unit=None, category=u"torr"),
+    Ingredient(name=u"Ost mild", purchase_unit=units.kilogram, category=u"mejeri"),
+    Ingredient(name=u"Ost med smak", purchase_unit=units.kilogram, category=u"mejeri"),
+    Ingredient(name=u"Vegetarisk ärtsoppa burk", purchase_unit=units.count, category=u"burk"),
+    Ingredient(name=u"Sirap, ljus", purchase_unit=units.grams, category=u"burk"),
 ])
 
 dishes = NameDict([
@@ -281,7 +285,10 @@ dishes = NameDict([
                 Ingredient(name=u"Gräddfil",             quantity=3 * units.liters),                
                 Ingredient(name=u"Lax",                  quantity=150 * 40 * units.gram),                
                 ], variants={
-                "laktosfri": [
+                u"helveg": [
+                    Ingredient(name=u"Vegetarisk ärtsoppa burk", quantity=1 * units.count)
+                ],
+                u"laktosfri": [
                     Ingredient(name=u"Gräddfil, laktosfri", quantity=1 * units.deciliters)
                     ],
                 u"mjölkfri": [
@@ -365,7 +372,10 @@ dishes = NameDict([
                 ], variants={
                 "laktosfri": [
                     Ingredient(name=u"Gräddfil, laktosfri", quantity=.5 * units.deciliters)
-                    ]
+                    ],
+                u"helveg": [
+                    Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
+                ]
                 }),
     Dish(name=u"Brunch", ingredients=[
                 Ingredient(name=u"Bacon",                quantity=12*125 * units.grams),                
@@ -417,9 +427,12 @@ dishes = NameDict([
                 Ingredient(name=u"Soppåsar mindre, rullar", quantity=2 * units.count),
                 Ingredient(name=u"Sopsäckar, stora, rullar", quantity=5 * units.count),
                 Ingredient(name=u"Riktigt jävla smör", quantity=2*units.kilogram),
+                Ingredient(name=u"Havregryn (bara)", quantity=3*units.kilogram),
+                Ingredient(name=u"Sirap, ljus", quantity=750*units.gram),
+                Ingredient(name=u"Vetemjöl", quantity=2*units.kilogram),
    ]),
     Dish(name=u"Frukost/fika", ingredients=[
-                 Ingredient(name=u"Jordgubbssylt", quantity=2*units.kilogram),
+                Ingredient(name=u"Jordgubbssylt", quantity=2*units.kilogram),
                 Ingredient(name=u"Josextrakt, äpple (måttet är för färdigblandad jos)", quantity=27*units.liter),
                 Ingredient(name=u"Josextrakt, apelsin (måttet är för färdigblandad jos)", quantity=27*units.liter),
                 Ingredient(name=u"Marmelad", quantity=3*units.kilogram),
@@ -440,12 +453,14 @@ dishes = NameDict([
                 Ingredient(name=u"Havregryn (bara)", quantity=5*1.5*units.kilogram),
                 Ingredient(name=u"Kakmix, chokladkaka", quantity=4*units.count),
                 Ingredient(name=u"Knäckebröd, skivor", quantity=2*units.kilogram),
-                Ingredient(name=u"Ljust bröd, skivor", quantity=9*40*units.count),
-                Ingredient(name=u"Mörkt bröd, skivor", quantity=40*units.count),
+                Ingredient(name=u"Ljust bröd (typ polar), skivor", quantity=9*40*units.count),
+                Ingredient(name=u"Mörkt bröd, skivor", quantity=7*40*units.count),
                 Ingredient(name=u"Mariekex", quantity=600*units.count),
                 Ingredient(name=u"Müsli", quantity=4*units.kilogram),
                 Ingredient(name=u"Skorpor", quantity=6*units.kilogram),
                 Ingredient(name=u"Tepåsar", quantity=150*units.count),
+                Ingredient(name=u"Ost mild", quantity=3*units.kilogram),
+                Ingredient(name=u"Ost med smak", quantity=5.3*units.kilogram),
     ],variants={
                 "glutenfri": [
                     Ingredient(name=u"Knäckebröd, glutenfritt, skivor", quantity=20 * units.count),
@@ -456,24 +471,24 @@ dishes = NameDict([
                     Ingredient(name=u"Yoghurt, laktosfri", quantity=1*units.liter),
                               ],
                 u"mjölkfri": [
-                    Ingredient(name=u"Soyamjölk", quantity=1*units.liter),
+                    Ingredient(name=u"Sojamjölk", quantity=1*units.liter),
                               ],
                     
                 }),
 ])
 
 menu = [
-    MenuItem(dish=dishes[u"Fänkål och kycklingsallad"], day=u"måndag", variants={"veg": 2}),
-    MenuItem(dish=dishes[u"Pasta & köttfärssås"], day=u"måndag", variants={"glutenfri": 1, "veg": 2}),
-    MenuItem(dish=dishes[u"Korv stroganoff"], day=u"tisdag", variants={u"mjölkfri": 3, "veg": 2}),
-    MenuItem(dish=dishes[u"Lax"], day=u"tisdag", variants={u"mjölkfri": 3}),
+    MenuItem(dish=dishes[u"Fänkål och kycklingsallad"], day=u"måndag", variants={"veg": 1}),
+    MenuItem(dish=dishes[u"Pasta & köttfärssås"], day=u"måndag", variants={"veg": 1}),
+    MenuItem(dish=dishes[u"Korv stroganoff"], day=u"tisdag", variants={u"mjölkfri": 1, "veg": 1}),
+    MenuItem(dish=dishes[u"Lax"], day=u"tisdag", variants={u"mjölkfri": 1, u"helveg": 1}),
     MenuItem(dish=dishes[u"2 x Indisk curry"], day=u"onsdag", variants={}),
-    MenuItem(dish=dishes[u"Porterstek"], day=u"onsdag", variants={"glutenfri": 2, "veg": 2, u"mjölkfri": 1}),
-    MenuItem(dish=dishes[u"Kassler med potatissallad"], day=u"torsdag", variants={"veg": 2}),
-    MenuItem(dish=dishes[u"Kycklinggryta med fetaost"], day=u"torsdag", variants={"veg": 2, u"mjölkfri": 2}),
-    MenuItem(dish=dishes[u"Sill och potatis"], day=u"fredag", variants={"laktosfri": 2}),
+    MenuItem(dish=dishes[u"Porterstek"], day=u"onsdag", variants={"veg": 1, u"mjölkfri": 1}),
+    MenuItem(dish=dishes[u"Kassler med potatissallad"], day=u"torsdag", variants={"veg": 1}),
+    MenuItem(dish=dishes[u"Kycklinggryta med fetaost"], day=u"torsdag", variants={"veg": 1, u"mjölkfri": 1}),
+    MenuItem(dish=dishes[u"Sill och potatis"], day=u"fredag", variants={"helveg": 1}),
     MenuItem(dish=dishes[u"Brunch"], day=u"lördag"),
-    MenuItem(dish=dishes[u"Gulasch"], day=u"lördag", variants={"veg": 2}),
+    MenuItem(dish=dishes[u"Gulasch"], day=u"lördag", variants={"veg": 1}),
     MenuItem(dish=dishes[u"Pytt-i-panna"], day=u"söndag"),    
     MenuItem(dish=dishes[u"Frukost/fika"], day=None, variants={"laktosfri": 2, u"mjölkfri": 1, "glutenfri": 1}),
     MenuItem(dish=dishes[u"Extras"], day=None),
@@ -488,12 +503,18 @@ translations = [
     ]
 
 prebought = [
-                Ingredient(name=u"Korvpålägg, skivor", quantity=50*units.count),
-                Ingredient(name=u"Köttpålägg, skivor", quantity=150*units.count),
+#                Ingredient(name=u"Korvpålägg, skivor", quantity=50*units.count),
+#                Ingredient(name=u"Köttpålägg, skivor", quantity=150*units.count),
                 Ingredient(name=u"Kycklingfilé", quantity=5*units.kilogram),
-                Ingredient(name=u"Sill, burk, blandat",  quantity=10 * units.count),
-                Ingredient(name=u"Vetemjöl",             quantity=940 * units.grams),
-                Ingredient(name=u"Tomatpuré",             quantity=350 * units.grams),
+#                Ingredient(name=u"Sill, burk, blandat",  quantity=10 * units.count),
+#                Ingredient(name=u"Vetemjöl",             quantity=940 * units.grams),
+#                Ingredient(name=u"Tomatpuré",             quantity=350 * units.grams),
+                Ingredient(name=u"Kikärtor, okokta",     quantity=1.2 * units.kilograms),
+                Ingredient(name=u"Kidneybönor, okokta",  quantity=1.4 * units.kilograms),
+                Ingredient(name=u"Fänkål",         quantity=7.2 * units.kilograms),
+                Ingredient(name=u"Valnötter",      quantity=15 * units.deciliters),
+                Ingredient(name=u"Ost med smak", quantity=4.3*units.kilogram),
+                Ingredient(name=u"Buljongtärning, grönsak", quantity=11*units.count),
             ]
 
 buy_later = [

--- a/data.py
+++ b/data.py
@@ -31,7 +31,10 @@ ingredient_types = NameDict([
     Ingredient(name=u"Basilika",       purchase_unit=None,            category=u"krydd"),
     Ingredient(name=u"Oregano",        purchase_unit=None,            category=u"krydd"),
     Ingredient(name=u"Timjan",         purchase_unit=None,            category=u"krydd"),
+    Ingredient(name=u"Curry",          purchase_unit=units.deciliters,category=u"krydd"),
+    
     Ingredient(name=u"Salt, grov",     purchase_unit=None,            category=u"krydd"),
+    Ingredient(name=u"Buljongtärning, fisk", purchase_unit=units.count, category=u"krydd"),
     Ingredient(name=u"Buljongtärning, höns", purchase_unit=units.count, category=u"krydd"),
     Ingredient(name=u"Buljongtärning, kött", purchase_unit=units.count, category=u"krydd"),
     Ingredient(name=u"Buljongtärning, grönsak", purchase_unit=units.count, category=u"krydd"),
@@ -50,6 +53,9 @@ ingredient_types = NameDict([
     Ingredient(name=u"Morötter",       purchase_unit=units.kilograms, category=u"grönt",
                conversions=[70 * units.grams / units.count]),
     Ingredient(name=u"Rotselleri",     purchase_unit=units.count,     category=u"grönt"),
+    Ingredient(name=u"Palsternacka",   purchase_unit=units.gram,      category=u"grönt"),
+    Ingredient(name=u"Purjolök",       purchase_unit=units.gram,      category=u"grönt"),
+
     Ingredient(name=u"Potatis",        purchase_unit=units.kilograms, category=u"grönt"),
     Ingredient(name=u"Dill, färsk, planta/motsv",    purchase_unit=units.count,            category=u"grönt"),
     Ingredient(name=u'Ingefära, färsk',purchase_unit=units.grams,     category=u"grönt"),
@@ -76,6 +82,8 @@ ingredient_types = NameDict([
                conversions=[60 * units.grams / units.deciliters]),
     Ingredient(name=u'Kidneybönor, avrunnen vikt',purchase_unit=units.kilogram, category=u"torr"),
     Ingredient(name=u'Koriander, färsk',purchase_unit=units.count,    category=u"grönt"),
+    Ingredient(name=u'Persilja, färsk',purchase_unit=units.count,    category=u"grönt"),
+    
     Ingredient(name=u'Gurkmeja',       purchase_unit=None,            category=u"krydd"),
     Ingredient(name=u'Vinbärsaft, outspädd, bra (typ Önos)',purchase_unit=units.liter, category=u"burk"),
     Ingredient(name=u'Kikärtor, avrunnen vikt',purchase_unit=units.kilogram, category=u"torr"),
@@ -107,6 +115,7 @@ ingredient_types = NameDict([
     Ingredient(name=u'Kolbasz',purchase_unit=units.kilogram, category=u"kyl"),
     Ingredient(name=u'Rödbetor till pytt-i-panna, portioner',purchase_unit=units.count, category=u"burk"),
     Ingredient(name=u'Pytt i panna, portioner',purchase_unit=units.count, category=u"frys"),
+    Ingredient(name=u'Pytt i panna, vegetarisk, portioner',purchase_unit=units.count, category=u"frys"),
 
     Ingredient(name=u'Grädde, laktosfri',purchase_unit=units.liter, category=u"mejeri"),
     Ingredient(name=u'Grädde, mjölkfri',purchase_unit=units.liter, category=u"mejeri"),
@@ -165,6 +174,8 @@ ingredient_types = NameDict([
     Ingredient(name=u'Cirtronjuice',purchase_unit=units.deciliter, category=u"burk"),
     Ingredient(name=u'Lax',purchase_unit=units.gram, category=u"kyl"),
 
+    Ingredient(name=u"Fisk (kolja, sej)",purchase_unit=units.gram, category=u"frys"),
+
     Ingredient(name=u"Ris, basmati", purchase_unit=units.kilograms, category=u"torr",
                conversions=[0.9 * units.grams / units.cm**3]),
     Ingredient(name=u"Sojamjölk", purchase_unit=units.liters, category=u"mejeri",),
@@ -210,15 +221,15 @@ dishes = NameDict([
                 Ingredient(name=u"Salt",                 quantity=None),
                 Ingredient(name=u"Pasta, Penne",         quantity=5 * units.kilogram),
                 ], variants={
-                "veg": [
+                u"veg": [
                     Ingredient(name=u"Quornfiléer", quantity=2*units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count)
                     ],
-                "glutenfri": [
+                u"glutenfri": [
                     Ingredient(name=u"Pasta, glutenfri, portioner", quantity=1*units.count)
                     ],
-                u"mjölkfri": [
-                    ],
+                u"mjölkfri": [],
+                u"laktosfri": [],
                 }),
     Dish(name=u"Pasta & köttfärssås", ingredients=[
                 Ingredient(name=u"Lök, gul",              quantity=15 * units.count),
@@ -274,7 +285,30 @@ dishes = NameDict([
                     Ingredient(name=u"Mjölkfri Creme Fraiche", quantity=.5 * units.deciliters),
                     ],
                 }),
-    Dish(name=u"Lax", ingredients=[
+    Dish(name=u"Fisksoppa", ingredients=[
+                Ingredient(name=u"Fisk (kolja, sej)",    quantity=5.5 * units.kilograms),
+                Ingredient(name=u"Potatis",              quantity=3   * units.kilograms),
+                Ingredient(name=u"Morötter",             quantity=2   * units.count),
+                Ingredient(name=u"Palsternacka",         quantity=1.2 * units.kilograms),
+                Ingredient(name=u"Buljongtärning, fisk", quantity=24  * units.count),
+                Ingredient(name=u"Socker",               quantity=1.5 * units.deciliters),
+                Ingredient(name=u"Purjolök",             quantity=2   * units.kilograms),
+                Ingredient(name=u"Vetemjöl",             quantity=2.5 * units.deciliters),
+                Ingredient(name=u"Persilja, färsk",      quantity=2   * units.count),
+                Ingredient(name=u"Curry",                quantity=0.5 * units.deciliters),
+                Ingredient(name=u"Salt, grov",           quantity=None),
+                Ingredient(name=u"Peppar, svart",        quantity=None),
+                Ingredient(name=u"Creme Fraiche, lätt",  quantity=2 * units.liters),
+                 ], variants={                
+                u"helveg": [
+                    Ingredient(name=u"Vegetarisk ärtsoppa burk", quantity=1 * units.count)
+                ],
+                u"laktosfri": [
+                    Ingredient(name=u"Gräddfil, laktosfri", quantity=1 * units.deciliters)
+                    ],
+                u"veg": [],
+                }),
+        Dish(name=u"Lax", ingredients=[
                 Ingredient(name=u"Salt, grov",           quantity=None),
                 Ingredient(name=u"Majonäs, burk",        quantity=2 * units.count),
                 Ingredient(name=u"Persilja, fryst",      quantity=1 * units.count),
@@ -283,7 +317,7 @@ dishes = NameDict([
                 Ingredient(name=u"Potatis",              quantity=16 * units.kilograms),
                 Ingredient(name=u"Dill, färsk, planta/motsv", quantity=4 * units.count),
                 Ingredient(name=u"Gräddfil",             quantity=3 * units.liters),                
-                Ingredient(name=u"Lax",                  quantity=150 * 40 * units.gram),                
+                Ingredient(name=u"Lax",                  quantity= 150 * 1.10 * 36 * units.gram),                
                 ], variants={
                 u"helveg": [
                     Ingredient(name=u"Vegetarisk ärtsoppa burk", quantity=1 * units.count)
@@ -312,9 +346,8 @@ dishes = NameDict([
                 Ingredient(name=u"Citroner",             quantity=3 * units.count),
                 Ingredient(name=u"Ris, basmati",         quantity=6 * units.liters),
                 ], variants={
-                "hannah": [
-                    Ingredient(name=u"Tofu, portioner", quantity=1 * units.count)
-                    ]
+                u"veg": [],
+                u"laktosfri": [],
                 }),
     Dish(name=u"Porterstek", ingredients=[
                 Ingredient(name=u"Högrev, benfri",       quantity=10 * units.kilograms),
@@ -334,7 +367,7 @@ dishes = NameDict([
                 Ingredient(name=u"Gurka",                quantity=5 * units.count),
                 Ingredient(name=u"Tomater",              quantity=10 * units.count),
                 ], variants={
-                "laktosfri": [
+                u"laktosfri": [
                     Ingredient(name=u"Grädde, laktosfri", quantity=1 * units.deciliters)
                     ],
                 u"mjölkfri": [
@@ -359,9 +392,10 @@ dishes = NameDict([
                 Ingredient(name=u"Fransk senap",         quantity=7 * units.tablespoons),
                 Ingredient(name=u"Peppar, svart",        quantity=None),
                 ], variants={
-                "veg": [
+                u"veg": [
                     Ingredient(name=u"Quornburgare", quantity=2 * units.count)
-                    ]
+                    ],
+                u"laktosfri": [],
                 }),
     Dish(name=u"Sill och potatis", ingredients=[
                 Ingredient(name=u"Sill, burk, blandat",  quantity=10 * units.count),
@@ -375,7 +409,8 @@ dishes = NameDict([
                     ],
                 u"helveg": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
-                ]
+                ],
+                u"veg": [],
                 }),
     Dish(name=u"Brunch", ingredients=[
                 Ingredient(name=u"Bacon",                quantity=12*125 * units.grams),                
@@ -386,7 +421,17 @@ dishes = NameDict([
                 Ingredient(name=u"Mjölk",                quantity=1 * units.liter),
                 Ingredient(name=u"Grädde",               quantity=1 * units.liter),
                 Ingredient(name=u"Riktigt jävla smör",               quantity=340 * units.grams),
-                ]),                
+                ], variants={
+                u"laktosfri": [
+                    Ingredient(name=u"Grädde, laktosfri", quantity=0.2 * units.deciliters)
+                    ],
+                u"helveg": [
+                    Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
+                ],
+                u"veg": [
+                    Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),                
+                ],
+                }),                
     Dish(name=u"Gulasch", ingredients=[
                 Ingredient(name=u"Grytkött",             quantity=5 * units.kilograms),
                 Ingredient(name=u"Kolbasz",              quantity=1 * units.kilograms),
@@ -404,16 +449,31 @@ dishes = NameDict([
                 "veg": [
                     Ingredient(name=u"Sojakorvar, Hälsans kök", quantity=4 * units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count),
-                    ]
+                    ],
+                "laktosfri" : []
                 }),
     Dish(name=u"Pytt-i-panna", ingredients=[
                 Ingredient(name=u"Rödbetor till pytt-i-panna, portioner", quantity=40 * units.count),
                 Ingredient(name=u"Pytt i panna, portioner", quantity=40 * units.count),
-    ]),
+                ], variants={
+                "veg": [
+                    Ingredient(name=u"Pytt i panna, vegetarisk, portioner", quantity=1 * units.count),
+                    ],
+                "helveg": [
+                    Ingredient(name=u"Pytt i panna, vegetarisk, portioner", quantity=1 * units.count),
+                    ],
+                "laktosfri" : []
+                }),
     Dish(name=u"Chili", ingredients=[
                 Ingredient(name=u"Ris, parboiled",          quantity=6 * units.liters),
                 ], variants={
-                "hannah": [ Ingredient(name=u"Färdigrätt, åt Hannah H E", quantity=1 * units.count) ]}),
+                "hannah": [ 
+                    Ingredient(name=u"Färdigrätt, åt Hannah H E", quantity=1 * units.count) 
+                    ],
+                u"veg" : [], # blandar inte i kött i en andel
+                u"helveg" : [], # blandar inte i kött i en andel
+                u"laktosfri" : [] # blandar inte i kött i en andel
+                }),
     Dish(name=u"Extras", ingredients=[
                 Ingredient(name=u"Ketchup", quantity=2 * units.count),
                 Ingredient(name=u"Brödbakningsmix", quantity=2 * units.count),
@@ -477,22 +537,29 @@ dishes = NameDict([
                 }),
 ])
 
+# laktosfri
+# mjölkfri
+# glutenfri
+# veg
+# helveg
+
 menu = [
     MenuItem(dish=dishes[u"Fänkål och kycklingsallad"], day=u"måndag"),
-    MenuItem(dish=dishes[u"Pasta & köttfärssås"], day=u"måndag"),
-    MenuItem(dish=dishes[u"Korv stroganoff"], day=u"tisdag"),
-    MenuItem(dish=dishes[u"Lax"], day=u"tisdag"),
-    MenuItem(dish=dishes[u"2 x Indisk curry"], day=u"onsdag", variants={}),
-    MenuItem(dish=dishes[u"Porterstek"], day=u"onsdag", variants={}),
-    MenuItem(dish=dishes[u"Kassler med potatissallad"], day=u"torsdag", variants={}),
-    MenuItem(dish=dishes[u"Kycklinggryta med fetaost"], day=u"torsdag", variants={}),
-    MenuItem(dish=dishes[u"Sill och potatis"], day=u"fredag", variants={}),
-    MenuItem(dish=dishes[u"Brunch"], day=u"lördag"),
-    MenuItem(dish=dishes[u"Gulasch"], day=u"lördag", variants={}),
-    MenuItem(dish=dishes[u"Pytt-i-panna"], day=u"söndag"),    
-    MenuItem(dish=dishes[u"Frukost/fika"], day=None, variants={}),
-    MenuItem(dish=dishes[u"Extras"], day=None),
-    MenuItem(dish=dishes[u"Chili"], day=None, variants={}),
+    MenuItem(dish=dishes[u"Pasta & köttfärssås"],       day=u"måndag"),
+    MenuItem(dish=dishes[u"Korv stroganoff"],           day=u"tisdag"),
+#    MenuItem(dish=dishes[u"Lax"], day=u"tisdag"),
+    MenuItem(dish=dishes[u"Fisksoppa"],                 day=u"tisdag",  variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"2 x Indisk curry"],          day=u"onsdag",  variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Porterstek"],                day=u"onsdag",  variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Kassler med potatissallad"], day=u"torsdag", variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Kycklinggryta med fetaost"], day=u"torsdag", variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Sill och potatis"],          day=u"fredag",  variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Brunch"],                    day=u"lördag",  variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Gulasch"],                   day=u"lördag",  variants={"laktosfri": 1, "veg": 3}),
+    MenuItem(dish=dishes[u"Pytt-i-panna"],              day=u"söndag",  variants={"laktosfri": 1, "veg": 3}),    
+    MenuItem(dish=dishes[u"Frukost/fika"],              day=None,       variants={"laktosfri": 1, u"mjölkfri": 0, "glutenfri": 1}),
+    MenuItem(dish=dishes[u"Extras"],                    day=None),
+    MenuItem(dish=dishes[u"Chili"],                     day=None,       variants={"laktosfri": 1, "veg": 3 }),
     ]
 
 translations = [
@@ -502,28 +569,28 @@ translations = [
     ("gram", "g")
     ]
 
-prebought = [
+# prebought = [
 #                Ingredient(name=u"Korvpålägg, skivor", quantity=50*units.count),
 #                Ingredient(name=u"Köttpålägg, skivor", quantity=150*units.count),
 #                Ingredient(name=u"Sill, burk, blandat",  quantity=10 * units.count),
 #                Ingredient(name=u"Vetemjöl",             quantity=940 * units.grams),
 #                Ingredient(name=u"Tomatpuré",             quantity=350 * units.grams),
-                Ingredient(name=u"Kikärtor, okokta",     quantity=1.2 * units.kilograms),
-                Ingredient(name=u"Kidneybönor, okokta",  quantity=1.4 * units.kilograms),
-                Ingredient(name=u"Fänkål",         quantity=7.2 * units.kilograms),
-                Ingredient(name=u"Valnötter",      quantity=15 * units.deciliters),
-                Ingredient(name=u"Ost med smak", quantity=4.3*units.kilogram),
-                Ingredient(name=u"Buljongtärning, grönsak", quantity=11*units.count),
-            ]
+#                Ingredient(name=u"Kikärtor, okokta",     quantity=1.2 * units.kilograms),
+#                Ingredient(name=u"Kidneybönor, okokta",  quantity=1.4 * units.kilograms),
+#                 Ingredient(name=u"Fänkål",         quantity=7.2 * units.kilograms),
+#                 Ingredient(name=u"Valnötter",      quantity=15 * units.deciliters),
+#                 Ingredient(name=u"Ost med smak", quantity=4.3*units.kilogram),
+#                 Ingredient(name=u"Buljongtärning, grönsak", quantity=11*units.count),
+#             ]
 prebought = [
-                Ingredient(name=u"Kycklingfilé",         quantity=5*units.kilogram),
-                Ingredient(name=u"Kikärtor, avrunnen vikt",     quantity=1.5 * units.kilograms),
-                Ingredient(name=u"Kidneybönor, avrunnen vikt",  quantity=1.5 * units.kilograms),
-                Ingredient(name=u"Fänkål",               quantity=5.4 * units.kilograms),
-                Ingredient(name=u"Lax",                  quantity=150 * 40 * units.gram),
+#                Ingredient(name=u"Kycklingfilé",         quantity=5*units.kilogram),
+#                Ingredient(name=u"Kikärtor, avrunnen vikt",     quantity=1.5 * units.kilograms),
+#                Ingredient(name=u"Kidneybönor, avrunnen vikt",  quantity=1.5 * units.kilograms),
+#                Ingredient(name=u"Fänkål",               quantity=5.4 * units.kilograms),
+#                Ingredient(name=u"Lax",                  quantity=150 * 40 * units.gram),
                 Ingredient(name=u"Buljongtärning, kött", quantity=20 * units.count),
                 Ingredient(name=u"Grädde",               quantity=10 * units.liters),
-                Ingredient(name=u"Tomatpuré",            quantity=440 * units.grams),
+#                Ingredient(name=u"Tomatpuré",            quantity=440 * units.grams),
 ]
 buy_later = [
                 Ingredient(name=u"Ägg",                  quantity=90 * units.count),                

--- a/data.py
+++ b/data.py
@@ -70,7 +70,7 @@ ingredient_types = NameDict([
     Ingredient(name=u"Mjölk",          purchase_unit=units.liters,    category=u"mejeri"),
     Ingredient(name=u"Gräddfil",       purchase_unit=units.liters,    category=u"mejeri"),
     Ingredient(name=u"Gräddfil, laktosfri",       purchase_unit=units.liters,    category=u"mejeri"),
-    Ingredient(name=u"Creme Fraiche, lätt",          purchase_unit=units.liters,    category=u"mejeri"),
+    Ingredient(name=u"Creme Fraiche",          purchase_unit=units.liters,    category=u"mejeri"),
     Ingredient(name=u"Köttfärs, nöt",  purchase_unit=units.kilograms, category=u"kyl"),
     Ingredient(name=u"Falukorv",       purchase_unit=units.kilograms, category=u"kyl"),
 
@@ -261,7 +261,7 @@ dishes = NameDict([
                 Ingredient(name=u"Fransk senap",         quantity=1.5 * units.deciliters),
                 Ingredient(name=u"Mjölk",                quantity=3 * units.liters),
                 Ingredient(name=u"Buljongtärning, grönsak", quantity=4 * units.count),
-                Ingredient(name=u"Creme Fraiche, lätt",  quantity=3 * units.liters),
+                Ingredient(name=u"Creme Fraiche",  quantity=3 * units.liters),
                 Ingredient(name=u"Ketchup",              quantity=.5 * units.count),
                 Ingredient(name=u"Sambal oelek",         quantity=4 * units.tablespoons),
                 Ingredient(name=u"Socker",               quantity=4 * units.deciliters),
@@ -288,7 +288,7 @@ dishes = NameDict([
     Dish(name=u"Fisksoppa", ingredients=[
                 Ingredient(name=u"Fisk (kolja, sej)",    quantity=5.5 * units.kilograms),
                 Ingredient(name=u"Potatis",              quantity=3   * units.kilograms),
-                Ingredient(name=u"Morötter",             quantity=2   * units.count),
+                Ingredient(name=u"Morötter",             quantity=2   * units.kilograms),
                 Ingredient(name=u"Palsternacka",         quantity=1.2 * units.kilograms),
                 Ingredient(name=u"Buljongtärning, fisk", quantity=24  * units.count),
                 Ingredient(name=u"Socker",               quantity=1.5 * units.deciliters),
@@ -298,7 +298,7 @@ dishes = NameDict([
                 Ingredient(name=u"Curry",                quantity=0.5 * units.deciliters),
                 Ingredient(name=u"Salt, grov",           quantity=None),
                 Ingredient(name=u"Peppar, svart",        quantity=None),
-                Ingredient(name=u"Creme Fraiche, lätt",  quantity=2 * units.liters),
+                Ingredient(name=u"Creme Fraiche",  quantity=2 * units.liters),
                  ], variants={                
                 u"helveg": [
                     Ingredient(name=u"Vegetarisk ärtsoppa burk", quantity=1 * units.count)
@@ -377,7 +377,7 @@ dishes = NameDict([
                     Ingredient(name=u"Quornfiléer", quantity=2*units.count),
                     Ingredient(name=u"Buljongtärning, grönsak", quantity=.5*units.count),
                     ],
-                "glutenfri": [
+                u"glutenfri": [
                     Ingredient(name=u"Maizena, ej ljus/mörk", quantity=None)
                 ]
                 }),
@@ -487,10 +487,11 @@ dishes = NameDict([
                 Ingredient(name=u"Soppåsar mindre, rullar", quantity=2 * units.count),
                 Ingredient(name=u"Sopsäckar, stora, rullar", quantity=5 * units.count),
                 Ingredient(name=u"Riktigt jävla smör", quantity=2*units.kilogram),
+                Ingredient(name=u"Grädde", quantity=1*units.liter),
                 Ingredient(name=u"Havregryn (bara)", quantity=3*units.kilogram),
                 Ingredient(name=u"Sirap, ljus", quantity=750*units.gram),
                 Ingredient(name=u"Vetemjöl", quantity=2*units.kilogram),
-   ]),
+    ]),
     Dish(name=u"Frukost/fika", ingredients=[
                 Ingredient(name=u"Jordgubbssylt", quantity=2*units.kilogram),
                 Ingredient(name=u"Josextrakt, äpple (måttet är för färdigblandad jos)", quantity=27*units.liter),
@@ -532,8 +533,7 @@ dishes = NameDict([
                               ],
                 u"mjölkfri": [
                     Ingredient(name=u"Sojamjölk", quantity=1*units.liter),
-                              ],
-                    
+                              ],                    
                 }),
 ])
 
@@ -583,17 +583,20 @@ translations = [
 #                 Ingredient(name=u"Buljongtärning, grönsak", quantity=11*units.count),
 #             ]
 prebought = [
-#                Ingredient(name=u"Kycklingfilé",         quantity=5*units.kilogram),
+                Ingredient(name=u"Kycklingfilé",            quantity=5   * units.kilogram),
+                Ingredient(name=u"Fisk (kolja, sej)",       quantity=2.5 * units.kilogram),
+                Ingredient(name=u"Buljongtärning, kött",    quantity=6   * units.count),
+                Ingredient(name=u"Buljongtärning, grönsak", quantity=8   * units.count),
+                Ingredient(name=u"Grädde",                  quantity=9   * units.liters),
+                Ingredient(name=u"Olja, raps",              quantity=9   * units.deciliters),
 #                Ingredient(name=u"Kikärtor, avrunnen vikt",     quantity=1.5 * units.kilograms),
 #                Ingredient(name=u"Kidneybönor, avrunnen vikt",  quantity=1.5 * units.kilograms),
 #                Ingredient(name=u"Fänkål",               quantity=5.4 * units.kilograms),
 #                Ingredient(name=u"Lax",                  quantity=150 * 40 * units.gram),
-                Ingredient(name=u"Buljongtärning, kött", quantity=20 * units.count),
-                Ingredient(name=u"Grädde",               quantity=10 * units.liters),
 #                Ingredient(name=u"Tomatpuré",            quantity=440 * units.grams),
 ]
 buy_later = [
-                Ingredient(name=u"Ägg",                  quantity=90 * units.count),                
-                Ingredient(name=u"Mjölk",                quantity=11 * units.liters),
+                Ingredient(name=u"Ägg",                  quantity=90 * units.count),    # simply do not buy them before
+                Ingredient(name=u"Mjölk",                quantity=8  * units.liters),
                 Ingredient(name=u"Bröd, ljust, skivor",  quantity=40 * units.count),                
              ]

--- a/html5.py
+++ b/html5.py
@@ -11,14 +11,15 @@ def shopping_list_to_html5(shopping_list, outputfile):
         print >>outputfile, u'<h1>' + escape(cat) + u'</h1>'
         print >>outputfile, u'<table class="tbl">'
         print >>outputfile, u'  <thead>'
-        print >>outputfile, u'    <tr><th colspan="2" class="amt">Mängd</th><th class="ingredient">Ingrediens</th><th class="sources">Till</th></tr>'
+        print >>outputfile, u'    <tr><th></th><th colspan="2" class="amt">Mängd</th><th class="ingredient">Ingrediens</th><th class="sources">Till</th></tr>'
         print >>outputfile, u'  </thead>'
         print >>outputfile, u'  <tbody>'
         for ingredient in sorted(ingredients):
             print >>outputfile, u'  <tr>'
+            print >>outputfile, u'    <td>&#x25a2;</td>'
             if ingredient.quantity:
                 formatst = u"%.1f"
-                print >>outputfile,u'    <td class="numeric amt-magnitude">' + format_decimal(ingredient.quantity.magnitude, locale='sv_SE') + '</td>'
+                print >>outputfile,u'    <td class="numeric amt-magnitude">' + format_decimal(round(ingredient.quantity.magnitude,2), locale='sv_SE') + '</td>'
                 print >>outputfile,u'    <td class="amt-unit">' + escape(alg.translate_unit(unicode(ingredient.quantity.units))) + '</td>'
             else:
                 print >>outputfile,u'    <td colspan="2"></td>'

--- a/main.py
+++ b/main.py
@@ -30,7 +30,8 @@ def main():
         html5.shopping_list_to_html5(shopping_list,f)
         
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        print unicode(e).encode("utf-8")
+    main()
+    #try:
+    #    main()
+    #except Exception as e:
+    #    print unicode(e).encode("utf-8")

--- a/main.py
+++ b/main.py
@@ -28,15 +28,21 @@ def main():
     for i, menu_item in enumerate(menu):
         if menu_item.dish.name == u"Porterstek":
             menu[i].dish = alg.scaled_dish(menu[i].dish, 28.0/36.0) # scale to amouont of people on change day
+        elif menu_item.dish.name == u"Extras":
+            pass # do not scale extras
         else:
             menu[i].dish = alg.scaled_dish(menu[i].dish, 24.0/36.0) # scale to amount of poeple on other days
 
     shopping_list = alg.make_shopping_list(menu, data.ingredient_types)
+    
+    with codecs.open("all-ingredients.html","w","utf-8") as f:
+        html5.shopping_list_to_html5(shopping_list,f)
+
     shopping_list = alg.subtract_from_shopping_list(shopping_list, data.prebought, data.ingredient_types)
     shopping_list = alg.subtract_from_shopping_list(shopping_list, data.buy_later, data.ingredient_types)
     with codecs.open("shopping.html","w","utf-8") as f:
-        html5.shopping_list_to_html5(shopping_list,f)
-        
+        html5.shopping_list_to_html5(shopping_list,f)    
+                
 if __name__ == "__main__":
     main()
     #try:

--- a/main.py
+++ b/main.py
@@ -25,10 +25,11 @@ def main():
     if found_undef:
         return
 
-    menu = list(alg.scaled_menu(menu, 0.75))
     for i, menu_item in enumerate(menu):
         if menu_item.dish.name == u"Porterstek":
-            menu[i].dish = alg.scaled_dish(menu[i].dish, 1/.75)
+            menu[i].dish = alg.scaled_dish(menu[i].dish, 28.0/36.0) # scale to amouont of people on change day
+        else:
+            menu[i].dish = alg.scaled_dish(menu[i].dish, 24.0/36.0) # scale to amount of poeple on other days
 
     shopping_list = alg.make_shopping_list(menu, data.ingredient_types)
     shopping_list = alg.subtract_from_shopping_list(shopping_list, data.prebought, data.ingredient_types)


### PR DESCRIPTION
Added new dish ("fisksoppa"), and and corrected a few subsequent typos

Adjustments of the scaling logic. However we should change the approach and instead do that on the menu definition, ie scale dish by dish instead on the total shopping list. to be able to
- scale day by day more easily
- create scaled ingredient lists for each dish to facilitate for the chefs

Added a generation of a  total ingredients list (that does not remove the pre-bought or buy-later items) so the chefs can see the total plan.

Renamed veg,helveg,etc to vegetarian,vegan (since it seems to be the defacto definition amongst our sailors)

Changed from lätt creme fraiche to standard creme fraiche (no idea why it was ever anything else) 